### PR TITLE
Collect ICESTORM_LC usage if possible

### DIFF
--- a/logLUTs.py
+++ b/logLUTs.py
@@ -49,7 +49,11 @@ def get_latest_stats():
     print("luts %d" % luts)
     print("max freq %2.2f MHz" % max_freq)
 
-    sha = repo.commit(repo.active_branch).hexsha
+    try:
+        sha = repo.commit(repo.active_branch).hexsha
+    except TypeError:
+        # Not on branch.
+        sha = repo.head.object.hexsha
     short_sha = repo.git.rev_parse(sha, short=True)
 
     return {    'commit'    : short_sha,


### PR DESCRIPTION
This has not been filled in for ECP5 because nowadays, `nextpnr-ecp5` doesn't pack FFs and LUTs into SLICEs.

This PR needs to be merged after #3. 

From my testing, logLUTs tolerates rows lacking a LC field or header, so this should be a backward-compat change.